### PR TITLE
Remove extraneous information in README/docs/comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ See [`DirectoryUrl::LetsEncryptStaging`].
 
 ### Implementation details
 
-The library tries to pull in as few dependencies as possible. (For now) that means using synchronous I/O and blocking cals. This doesn't rule out a futures based version later.
-
-It is written by following the [ACME draft spec 18](https://tools.ietf.org/html/draft-ietf-acme-acme-18), and relies heavily on the [openssl](https://docs.rs/openssl/) crate to make JWK/JWT and sign requests to the API.
+This library follows the [ACME draft spec 18](https://tools.ietf.org/html/draft-ietf-acme-acme-18).
 
 License: MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,13 +147,8 @@
 //!
 //! ## Implementation details
 //!
-//! The library tries to pull in as few dependencies as possible. (For now) that means using
-//! synchronous I/O and blocking cals. This doesn't rule out a futures based version later.
-//!
-//! It is written by following the
-//! [ACME draft spec 18](https://tools.ietf.org/html/draft-ietf-acme-acme-18), and relies
-//! heavily on the [openssl](https://docs.rs/openssl/) crate to make JWK/JWT and sign requests
-//! to the API.
+//! This library follows the
+//! [ACME draft spec 18](https://tools.ietf.org/html/draft-ietf-acme-acme-18).
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -222,7 +222,7 @@ impl CsrOrder {
         self.finalize_signing_key(signing_key, delay).await
     }
 
-    /// Lower level finalize call that works directly with the openssl crate structures.
+    /// Lower level finalize call.
     ///
     /// Creates the CSR for the domains in the order and submit it to the ACME API.
     ///


### PR DESCRIPTION
I personally need an ACME v2 library without `openssl` and ideally with `async`. This PR makes the README and docs more representative of the current state of the code.